### PR TITLE
fix libhost1x compilation

### DIFF
--- a/src/libhost1x/host1x-drm.c
+++ b/src/libhost1x/host1x-drm.c
@@ -581,7 +581,6 @@ static int drm_channel_submit(struct host1x_client *client,
 	args.num_syncpts = 1;
 	args.num_cmdbufs = job->num_pushbufs;
 	args.num_relocs = num_relocs;
-	args.submit_version = 0;
 	args.num_waitchks = 0;
 	args.waitchk_mask = 0;
 	args.timeout = 1000;


### PR DESCRIPTION
.submit_version field was removed from drm_tegra_submit struct after updating
tegra_drm.h, remove it from host1x-drm.c to fix libhost1x compilation.
