### PR TITLE
grate: provide proper in/out attributes bit mask to VPE

### DIFF
--- a/src/libgrate/grate.c
+++ b/src/libgrate/grate.c
@@ -533,9 +533,9 @@ void grate_draw_elements(struct grate *grate, enum grate_primitive type,
 		host1x_pushbuf_push(pb, ptr[3]);
 	}
 
-	/* varying flags */
+	/* select VPE in/out buffers */
 	host1x_pushbuf_push(pb, HOST1X_OPCODE_INCR(0x120, 0x01));
-	host1x_pushbuf_push(pb, 0x00030081);
+	host1x_pushbuf_push(pb, program->attributes_mask);
 
 	/* polygon offset */
 	host1x_pushbuf_push(pb, HOST1X_OPCODE_INCR(0x344, 0x02));

--- a/src/libgrate/libgrate-private.h
+++ b/src/libgrate/libgrate-private.h
@@ -47,6 +47,7 @@ struct grate_program {
 
 	struct grate_attribute *attributes;
 	unsigned int num_attributes;
+	uint32_t attributes_mask;
 
 	struct grate_uniform *uniforms;
 	unsigned int num_uniforms;

--- a/src/libgrate/shader-cgc.c
+++ b/src/libgrate/shader-cgc.c
@@ -224,14 +224,22 @@ void grate_program_link(struct grate_program *program)
 
 	for (i = 0; i < shader->num_symbols; i++) {
 		struct cgc_symbol *symbol = &shader->symbols[i];
+		uint32_t attr_mask = (1 << symbol->location);
+
+		if (symbol->location == -1)
+			continue;
 
 		switch (symbol->kind) {
 		case GLSL_KIND_ATTRIBUTE:
 			printf("attribute %s @%u", symbol->name,
 			       symbol->location);
 
-			if (symbol->input)
+			if (symbol->input) {
 				grate_program_add_attribute(program, symbol);
+				program->attributes_mask |= attr_mask << 16;
+			} else {
+				program->attributes_mask |= attr_mask;
+			}
 
 			break;
 
@@ -266,6 +274,9 @@ void grate_program_link(struct grate_program *program)
 
 	for (i = 0; i < shader->num_symbols; i++) {
 		struct cgc_symbol *symbol = &shader->symbols[i];
+
+		if (symbol->location == -1)
+			continue;
 
 		switch (symbol->kind) {
 		case GLSL_KIND_ATTRIBUTE:


### PR DESCRIPTION
We can provide proper bit mask instead of hardcoded value.
