### PR TITLE
grate: consolidate cull-flags

### DIFF
--- a/include/tgr_3d.xml.h
+++ b/include/tgr_3d.xml.h
@@ -8,8 +8,8 @@ http://github.com/envytools/envytools/
 git clone https://github.com/envytools/envytools.git
 
 The rules-ng-ng source files this header was generated from are:
-- /envytools/rnndb/tgr_3d.xml          (  11967 bytes, from 2017-01-30 23:18:22)
-- /envytools/rnndb/grate_copyright.xml (   1556 bytes, from 2017-01-23 10:01:40)
+- /home/kusma/src/envytools/rnndb/tgr_3d.xml          (  12088 bytes, from 2017-01-31 23:55:31)
+- /home/kusma/src/envytools/rnndb/grate_copyright.xml (   1556 bytes, from 2017-01-29 21:14:55)
 
 Copyright (C) 2012-2017 by the following authors:
 - Erik Faye-Lund <kusmabite@gmail.com> (kusma)
@@ -49,6 +49,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define PRIMITIVE_TYPE_TRIANGLE_FAN				0x00000006
 #define PROVOKING_VERTEX_FIRST					0x00000000
 #define PROVOKING_VERTEX_LAST					0x00000001
+#define CULL_FACE_NONE						0x00000000
+#define CULL_FACE_CCW						0x00000001
+#define CULL_FACE_CW						0x00000002
+#define CULL_FACE_BOTH						0x00000003
 #define ATTRIB_TYPE_UBYTE					0x00000000
 #define ATTRIB_TYPE_UBYTE_NORM					0x00000001
 #define ATTRIB_TYPE_SBYTE					0x00000002
@@ -197,8 +201,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define TGR3D_CULL_FACE_LINKER_SETUP_LINKER_INST_COUNT__MASK	0x000003e0
 #define TGR3D_CULL_FACE_LINKER_SETUP_LINKER_INST_COUNT__SHIFT	5
 #define TGR3D_CULL_FACE_LINKER_SETUP_FRONT_CW			0x00008000
-#define TGR3D_CULL_FACE_LINKER_SETUP_CULL_CCW			0x00010000
-#define TGR3D_CULL_FACE_LINKER_SETUP_CULL_CW			0x00020000
+#define TGR3D_CULL_FACE_LINKER_SETUP_CULL_FACE__MASK		0x00030000
+#define TGR3D_CULL_FACE_LINKER_SETUP_CULL_FACE__SHIFT		16
 #define TGR3D_CULL_FACE_LINKER_SETUP_UNK_18_31__MASK		0xfffc0000
 #define TGR3D_CULL_FACE_LINKER_SETUP_UNK_18_31__SHIFT		18
 

--- a/src/libgrate/grate-3d-ctx.c
+++ b/src/libgrate/grate-3d-ctx.c
@@ -381,14 +381,10 @@ void grate_3d_ctx_set_front_direction_is_cw(struct grate_3d_ctx *ctx,
 	ctx->tri_face_front_cw = front_cw;
 }
 
-void grate_3d_ctx_set_cull_ccw(struct grate_3d_ctx *ctx, bool cull_ccw)
+void grate_3d_ctx_set_cull_face(struct grate_3d_ctx *ctx,
+                                enum grate_cull_face cull_face)
 {
-	ctx->cull_ccw = cull_ccw;
-}
-
-void grate_3d_ctx_set_cull_cw(struct grate_3d_ctx *ctx, bool cull_cw)
-{
-	ctx->cull_cw = cull_cw;
+	ctx->cull_face = cull_face;
 }
 
 void grate_3d_ctx_set_scissor(struct grate_3d_ctx *ctx,

--- a/src/libgrate/grate-3d.c
+++ b/src/libgrate/grate-3d.c
@@ -145,6 +145,25 @@ static void grate_3d_set_guardband(struct host1x_pushbuf *pb,
 	}
 }
 
+static int get_cull_face(struct grate_3d_ctx *ctx)
+{
+	switch (ctx->cull_face) {
+	case GRATE_CULL_FACE_NONE:
+		return CULL_FACE_NONE;
+
+	case GRATE_CULL_FACE_FRONT:
+		return ctx->tri_face_front_cw ? CULL_FACE_CW : CULL_FACE_CCW;
+
+	case GRATE_CULL_FACE_BACK:
+		return ctx->tri_face_front_cw ? CULL_FACE_CCW : CULL_FACE_CW;
+
+	case GRATE_CULL_FACE_BOTH:
+		return CULL_FACE_BOTH;
+	}
+
+	return CULL_FACE_NONE; /* just a stupid fallback */
+}
+
 static void grate_3d_set_cull_face_and_linker_inst_nb(struct host1x_pushbuf *pb,
 						      struct grate_3d_ctx *ctx)
 {
@@ -153,10 +172,9 @@ static void grate_3d_set_cull_face_and_linker_inst_nb(struct host1x_pushbuf *pb,
 
 	value |= TGR3D_BOOL(CULL_FACE_LINKER_SETUP, FRONT_CW,
 			    ctx->tri_face_front_cw);
-	value |= TGR3D_BOOL(CULL_FACE_LINKER_SETUP, CULL_CCW,
-			    ctx->cull_ccw);
-	value |= TGR3D_BOOL(CULL_FACE_LINKER_SETUP, CULL_CW,
-			    ctx->cull_cw );
+	value |= TGR3D_VAL(CULL_FACE_LINKER_SETUP, CULL_FACE,
+			    get_cull_face(ctx));
+
 	value |= TGR3D_VAL(CULL_FACE_LINKER_SETUP, LINKER_INST_COUNT,
 			   ctx->program->linker->linker_inst_nb - 1);
 	value |= TGR3D_VAL(CULL_FACE_LINKER_SETUP, UNK_18_31, unk);

--- a/src/libgrate/grate-3d.h
+++ b/src/libgrate/grate-3d.h
@@ -105,8 +105,7 @@ struct grate_3d_ctx {
 	bool guarband_enabled;
 	bool provoking_vtx_last;
 	bool tri_face_front_cw;
-	bool cull_ccw;
-	bool cull_cw;
+	enum grate_cull_face cull_face;
 	uint32_t dither_unk;
 	uint32_t point_params;
 	uint32_t line_params;

--- a/src/libgrate/grate.h
+++ b/src/libgrate/grate.h
@@ -43,6 +43,14 @@ struct grate;
 #define GRATE_SINGLE_BUFFERED (0 << 0)
 #define GRATE_DOUBLE_BUFFERED (1 << 0)
 
+enum grate_cull_face
+{
+	GRATE_CULL_FACE_NONE  = 0,
+	GRATE_CULL_FACE_FRONT = 1,
+	GRATE_CULL_FACE_BACK  = 2,
+	GRATE_CULL_FACE_BOTH  = 3
+};
+
 struct grate_framebuffer *grate_framebuffer_create(struct grate *grate,
 						   unsigned int width,
 						   unsigned int height,
@@ -175,8 +183,8 @@ void grate_3d_ctx_set_line_width(struct grate_3d_ctx *ctx, float width);
 void grate_3d_ctx_use_guardband(struct grate_3d_ctx *ctx, bool enabled);
 void grate_3d_ctx_set_front_direction_is_cw(struct grate_3d_ctx *ctx,
 					    bool front_cw);
-void grate_3d_ctx_set_cull_ccw(struct grate_3d_ctx *ctx, bool cull_ccw);
-void grate_3d_ctx_set_cull_cw(struct grate_3d_ctx *ctx, bool cull_cw);
+void grate_3d_ctx_set_cull_face(struct grate_3d_ctx *ctx,
+                                enum grate_cull_face cull_face);
 void grate_3d_ctx_set_scissor(struct grate_3d_ctx *ctx,
 			      unsigned x, unsigned width,
 			      unsigned y, unsigned height);

--- a/tests/grate/cube-textured.c
+++ b/tests/grate/cube-textured.c
@@ -218,8 +218,7 @@ int main(int argc, char *argv[])
 	grate_3d_ctx_set_viewport_scale(ctx, options.width, options.height, 0.5f);
 	grate_3d_ctx_use_guardband(ctx, true);
 	grate_3d_ctx_set_front_direction_is_cw(ctx, false);
-	grate_3d_ctx_set_cull_ccw(ctx, false);
-	grate_3d_ctx_set_cull_cw(ctx, true);
+	grate_3d_ctx_set_cull_face(ctx, GRATE_CULL_FACE_BACK);
 	grate_3d_ctx_set_scissor(ctx, 0, options.width, 0, options.height);
 	grate_3d_ctx_set_point_coord_range(ctx, 0.0f, 1.0f, 0.0f, 1.0f);
 	grate_3d_ctx_set_polygon_offset(ctx, 0.0f, 0.0f);

--- a/tests/grate/cube.c
+++ b/tests/grate/cube.c
@@ -208,8 +208,7 @@ int main(int argc, char *argv[])
 	grate_3d_ctx_set_viewport_scale(ctx, options.width, options.height, 0.5f);
 	grate_3d_ctx_use_guardband(ctx, true);
 	grate_3d_ctx_set_front_direction_is_cw(ctx, false);
-	grate_3d_ctx_set_cull_ccw(ctx, false);
-	grate_3d_ctx_set_cull_cw(ctx, false);
+	grate_3d_ctx_set_cull_face(ctx, GRATE_CULL_FACE_NONE);
 	grate_3d_ctx_set_scissor(ctx, 0, options.width, 0, options.height);
 	grate_3d_ctx_set_point_coord_range(ctx, 0.0f, 1.0f, 0.0f, 1.0f);
 	grate_3d_ctx_set_polygon_offset(ctx, 0.0f, 0.0f);

--- a/tests/grate/quad.c
+++ b/tests/grate/quad.c
@@ -128,8 +128,7 @@ int main(int argc, char *argv[])
 	grate_3d_ctx_set_viewport_scale(ctx, options.width, options.height, 0.5f);
 	grate_3d_ctx_use_guardband(ctx, true);
 	grate_3d_ctx_set_front_direction_is_cw(ctx, false);
-	grate_3d_ctx_set_cull_ccw(ctx, false);
-	grate_3d_ctx_set_cull_cw(ctx, false);
+	grate_3d_ctx_set_cull_face(ctx, GRATE_CULL_FACE_NONE);
 	grate_3d_ctx_set_scissor(ctx, 0, options.width, 0, options.height);
 	grate_3d_ctx_set_point_coord_range(ctx, 0.0f, 1.0f, 0.0f, 1.0f);
 	grate_3d_ctx_set_polygon_offset(ctx, 0.0f, 0.0f);

--- a/tests/grate/triangle-rotate.c
+++ b/tests/grate/triangle-rotate.c
@@ -134,8 +134,7 @@ int main(int argc, char *argv[])
 	grate_3d_ctx_set_viewport_scale(ctx, options.width, options.height, 0.5f);
 	grate_3d_ctx_use_guardband(ctx, true);
 	grate_3d_ctx_set_front_direction_is_cw(ctx, false);
-	grate_3d_ctx_set_cull_ccw(ctx, false);
-	grate_3d_ctx_set_cull_cw(ctx, false);
+	grate_3d_ctx_set_cull_face(ctx, GRATE_CULL_FACE_NONE);
 	grate_3d_ctx_set_scissor(ctx, 0, options.width, 0, options.height);
 	grate_3d_ctx_set_point_coord_range(ctx, 0.0f, 1.0f, 0.0f, 1.0f);
 	grate_3d_ctx_set_polygon_offset(ctx, 0.0f, 0.0f);

--- a/tests/grate/triangle.c
+++ b/tests/grate/triangle.c
@@ -125,8 +125,7 @@ int main(int argc, char *argv[])
 	grate_3d_ctx_set_viewport_scale(ctx, options.width, options.height, 0.5f);
 	grate_3d_ctx_use_guardband(ctx, true);
 	grate_3d_ctx_set_front_direction_is_cw(ctx, false);
-	grate_3d_ctx_set_cull_ccw(ctx, false);
-	grate_3d_ctx_set_cull_cw(ctx, false);
+	grate_3d_ctx_set_cull_face(ctx, GRATE_CULL_FACE_NONE);
 	grate_3d_ctx_set_scissor(ctx, 0, options.width, 0, options.height);
 	grate_3d_ctx_set_point_coord_range(ctx, 0.0f, 1.0f, 0.0f, 1.0f);
 	grate_3d_ctx_set_polygon_offset(ctx, 0.0f, 0.0f);

--- a/tools/assembler.c
+++ b/tools/assembler.c
@@ -267,8 +267,7 @@ int main(int argc, char *argv[])
 	grate_3d_ctx_set_viewport_scale(ctx, options.width, options.height, 0.5f);
 	grate_3d_ctx_use_guardband(ctx, true);
 	grate_3d_ctx_set_front_direction_is_cw(ctx, false);
-	grate_3d_ctx_set_cull_ccw(ctx, false);
-	grate_3d_ctx_set_cull_cw(ctx, false);
+	grate_3d_ctx_set_cull_face(ctx, GRATE_CULL_FACE_NONE);
 	grate_3d_ctx_set_scissor(ctx, 0, options.width, 0, options.height);
 	grate_3d_ctx_set_point_coord_range(ctx, 0.0f, 1.0f, 0.0f, 1.0f);
 	grate_3d_ctx_set_polygon_offset(ctx, 0.0f, 0.0f);


### PR DESCRIPTION
This allows us to use OpenGL semantics, and reduces the amount of
function calls a tad.

Depends on grate-driver/envytools#1