### PR TITLE
cleanup nvmap flags

### DIFF
--- a/src/libhost1x/host1x-nvhost.c
+++ b/src/libhost1x/host1x-nvhost.c
@@ -92,31 +92,31 @@ static struct host1x_bo *nvhost_bo_create(struct host1x *host1x,
 	switch (flags & ~HOST1X_BO_CREATE_DRM_FLAGS_MASK) {
 	case 1: /* framebuffer */
 		heap_mask = 1 << 0;
-		flags = 1 << 0;
+		flags = NVMAP_HANDLE_WRITE_COMBINE;
 		align = 0x100;
 		break;
 
 	case 2: /* command buffer */
 		heap_mask = 1 << 0;
-		flags = 0x0a000001;
+		flags = 0x0a000000 | NVMAP_HANDLE_WRITE_COMBINE;
 		align = 0x20;
 		break;
 
 	case 3: /* scratch */
 		heap_mask = 1 << 30;
-		flags = 1 << 0;
+		flags = NVMAP_HANDLE_WRITE_COMBINE;
 		align = 0x20;
 		break;
 
 	case 4: /* attributes */
 		heap_mask = 1 << 30;
-		flags = 0x3d000001;
+		flags = 0x3d000000 | NVMAP_HANDLE_WRITE_COMBINE;
 		align = 0x4;
 		break;
 
 	default:
 		heap_mask = 1 << 30;
-		flags = 0x3d000001;
+		flags = 0x3d000000 | NVMAP_HANDLE_WRITE_COMBINE;
 		align = 0x4;
 		break;
 	}

--- a/src/libhost1x/host1x-nvhost.c
+++ b/src/libhost1x/host1x-nvhost.c
@@ -98,7 +98,7 @@ static struct host1x_bo *nvhost_bo_create(struct host1x *host1x,
 
 	case 2: /* command buffer */
 		heap_mask = 1 << 0;
-		flags = 0x0a000000 | NVMAP_HANDLE_WRITE_COMBINE;
+		flags = NVMAP_HANDLE_WRITE_COMBINE;
 		align = 0x20;
 		break;
 
@@ -110,13 +110,13 @@ static struct host1x_bo *nvhost_bo_create(struct host1x *host1x,
 
 	case 4: /* attributes */
 		heap_mask = 1 << 30;
-		flags = 0x3d000000 | NVMAP_HANDLE_WRITE_COMBINE;
+		flags = NVMAP_HANDLE_WRITE_COMBINE;
 		align = 0x4;
 		break;
 
 	default:
 		heap_mask = 1 << 30;
-		flags = 0x3d000000 | NVMAP_HANDLE_WRITE_COMBINE;
+		flags = NVMAP_HANDLE_WRITE_COMBINE;
 		align = 0x4;
 		break;
 	}

--- a/src/libhost1x/nvhost-nvmap.h
+++ b/src/libhost1x/nvhost-nvmap.h
@@ -46,6 +46,17 @@ nvmap_handle_get_offset(struct nvmap_handle *handle, void *ptr)
 	return (unsigned long)ptr - (unsigned long)handle->ptr;
 }
 
+#define NVMAP_HANDLE_UNREACHABLE     (0x0ul << 0)
+#define NVMAP_HANDLE_WRITE_COMBINE   (0x1ul << 0)
+#define NVMAP_HANDLE_INNER_CACHEABLE (0x2ul << 0)
+#define NVMAP_HANDLE_CACHEABLE       (0x3ul << 0)
+#define NVMAP_HANDLE_CACHE_FLAG      (0x3ul << 0)
+
+#define NVMAP_HANDLE_SECURE          (0x1ul << 2)
+#define NVMAP_HANDLE_KIND_SPECIFIED  (0x1ul << 3)
+#define NVMAP_HANDLE_COMPR_SPECIFIED (0x1ul << 4)
+#define NVMAP_HANDLE_ZEROED_PAGES    (0x1ul << 5)
+
 struct nvmap_handle *nvmap_handle_create(struct nvmap *nvmap, size_t size);
 void nvmap_handle_free(struct nvmap *nvmap, struct nvmap_handle *handle);
 int nvmap_handle_alloc(struct nvmap *nvmap, struct nvmap_handle *handle,

--- a/tests/nvhost/gr2d.c
+++ b/tests/nvhost/gr2d.c
@@ -141,7 +141,7 @@ struct nvhost_gr2d *nvhost_gr2d_open(struct nvmap *nvmap,
 	}
 
 	err = nvmap_handle_alloc(nvmap, gr2d->buffer, 1 << 0,
-	                         0x0a000000 | NVMAP_HANDLE_WRITE_COMBINE, 0x20);
+	                         NVMAP_HANDLE_WRITE_COMBINE, 0x20);
 	if (err < 0) {
 		nvmap_handle_free(nvmap, gr2d->buffer);
 		nvhost_client_exit(&gr2d->client);

--- a/tests/nvhost/gr2d.c
+++ b/tests/nvhost/gr2d.c
@@ -140,7 +140,8 @@ struct nvhost_gr2d *nvhost_gr2d_open(struct nvmap *nvmap,
 		return NULL;
 	}
 
-	err = nvmap_handle_alloc(nvmap, gr2d->buffer, 1 << 0, 0x0a000001, 0x20);
+	err = nvmap_handle_alloc(nvmap, gr2d->buffer, 1 << 0,
+	                         0x0a000000 | NVMAP_HANDLE_WRITE_COMBINE, 0x20);
 	if (err < 0) {
 		nvmap_handle_free(nvmap, gr2d->buffer);
 		nvhost_client_exit(&gr2d->client);
@@ -164,7 +165,8 @@ struct nvhost_gr2d *nvhost_gr2d_open(struct nvmap *nvmap,
 		return NULL;
 	}
 
-	err = nvmap_handle_alloc(nvmap, gr2d->scratch, 1 << 30, 1 << 0, 0x20);
+	err = nvmap_handle_alloc(nvmap, gr2d->scratch, 1 << 30,
+	                         NVMAP_HANDLE_WRITE_COMBINE, 0x20);
 	if (err < 0) {
 		nvmap_handle_free(nvmap, gr2d->scratch);
 		nvmap_handle_free(nvmap, gr2d->buffer);

--- a/tests/nvhost/gr3d.c
+++ b/tests/nvhost/gr3d.c
@@ -799,7 +799,7 @@ struct nvhost_gr3d *nvhost_gr3d_open(struct nvmap *nvmap,
 	}
 
 	err = nvmap_handle_alloc(nvmap, gr3d->buffer, 1 << 0,
-	                         0x0a000000 | NVMAP_HANDLE_WRITE_COMBINE, 0x20);
+	                         NVMAP_HANDLE_WRITE_COMBINE, 0x20);
 	if (err < 0) {
 		nvmap_handle_free(nvmap, gr3d->buffer);
 		nvhost_client_exit(&gr3d->client);
@@ -824,7 +824,7 @@ struct nvhost_gr3d *nvhost_gr3d_open(struct nvmap *nvmap,
 	}
 
 	err = nvmap_handle_alloc(nvmap, gr3d->attributes, 1 << 30,
-	                         0x3d000000 | NVMAP_HANDLE_WRITE_COMBINE, 0x4);
+	                         NVMAP_HANDLE_WRITE_COMBINE, 0x4);
 	if (err < 0) {
 		nvmap_handle_free(nvmap, gr3d->attributes);
 		nvmap_handle_free(nvmap, gr3d->buffer);

--- a/tests/nvhost/gr3d.c
+++ b/tests/nvhost/gr3d.c
@@ -798,7 +798,8 @@ struct nvhost_gr3d *nvhost_gr3d_open(struct nvmap *nvmap,
 		return NULL;
 	}
 
-	err = nvmap_handle_alloc(nvmap, gr3d->buffer, 1 << 0, 0x0a000001, 0x20);
+	err = nvmap_handle_alloc(nvmap, gr3d->buffer, 1 << 0,
+	                         0x0a000000 | NVMAP_HANDLE_WRITE_COMBINE, 0x20);
 	if (err < 0) {
 		nvmap_handle_free(nvmap, gr3d->buffer);
 		nvhost_client_exit(&gr3d->client);
@@ -822,8 +823,8 @@ struct nvhost_gr3d *nvhost_gr3d_open(struct nvmap *nvmap,
 		return NULL;
 	}
 
-	err = nvmap_handle_alloc(nvmap, gr3d->attributes, 1 << 30, 0x3d000001,
-				 0x4);
+	err = nvmap_handle_alloc(nvmap, gr3d->attributes, 1 << 30,
+	                         0x3d000000 | NVMAP_HANDLE_WRITE_COMBINE, 0x4);
 	if (err < 0) {
 		nvmap_handle_free(nvmap, gr3d->attributes);
 		nvmap_handle_free(nvmap, gr3d->buffer);

--- a/tests/nvhost/nvmap.c
+++ b/tests/nvhost/nvmap.c
@@ -307,7 +307,8 @@ struct nvmap_framebuffer *nvmap_framebuffer_create(struct nvmap *nvmap,
 		return NULL;
 	}
 
-	err = nvmap_handle_alloc(nvmap, fb->handle, 1 << 0, 1 << 0, 0x100);
+	err = nvmap_handle_alloc(nvmap, fb->handle, 1 << 0,
+	                         NVMAP_HANDLE_WRITE_COMBINE, 0x100);
 	if (err < 0) {
 		free(fb);
 		return NULL;

--- a/tests/nvhost/nvmap.h
+++ b/tests/nvhost/nvmap.h
@@ -47,6 +47,17 @@ nvmap_handle_get_offset(struct nvmap_handle *handle, void *ptr)
 	return (unsigned long)ptr - (unsigned long)handle->ptr;
 }
 
+#define NVMAP_HANDLE_UNREACHABLE     (0x0ul << 0)
+#define NVMAP_HANDLE_WRITE_COMBINE   (0x1ul << 0)
+#define NVMAP_HANDLE_INNER_CACHEABLE (0x2ul << 0)
+#define NVMAP_HANDLE_CACHEABLE       (0x3ul << 0)
+#define NVMAP_HANDLE_CACHE_FLAG      (0x3ul << 0)
+
+#define NVMAP_HANDLE_SECURE          (0x1ul << 2)
+#define NVMAP_HANDLE_KIND_SPECIFIED  (0x1ul << 3)
+#define NVMAP_HANDLE_COMPR_SPECIFIED (0x1ul << 4)
+#define NVMAP_HANDLE_ZEROED_PAGES    (0x1ul << 5)
+
 struct nvmap_handle *nvmap_handle_create(struct nvmap *nvmap, size_t size);
 void nvmap_handle_free(struct nvmap *nvmap, struct nvmap_handle *handle);
 int nvmap_handle_alloc(struct nvmap *nvmap, struct nvmap_handle *handle,


### PR DESCRIPTION
It seems nvmap, especially in recent versions of L4T doesn't do much about these flags at all. But this here seems to be the contract.