### PR TITLE
avoid linker-crash

### DIFF
--- a/src/libgrate/shader-cgc.c
+++ b/src/libgrate/shader-cgc.c
@@ -22,6 +22,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -335,6 +336,8 @@ void grate_program_link(struct grate_program *program)
 {
 	struct cgc_shader *shader;
 	unsigned int i;
+
+	assert(program);
 
 	if (!program->vs) {
 		grate_error("No vertex program?");

--- a/tests/grate/cube-textured.c
+++ b/tests/grate/cube-textured.c
@@ -201,6 +201,11 @@ int main(int argc, char *argv[])
 	linker = grate_shader_parse_linker_asm(shader_linker);
 
 	program = grate_program_new(grate, vs, fs, linker);
+	if (!program) {
+		fprintf(stderr, "grate_program_new() failed\n");
+		return 1;
+	}
+
 	grate_program_link(program);
 
 	mvp_loc = grate_get_vertex_uniform_location(program, "mvp");

--- a/tests/grate/cube-textured2.c
+++ b/tests/grate/cube-textured2.c
@@ -227,9 +227,19 @@ int main(int argc, char *argv[])
 	}
 
 	cube_program = grate_program_new(grate, cube_vs, cube_fs, cube_linker);
+	if (!cube_program) {
+		fprintf(stderr, "grate_program_new() failed\n");
+		return 1;
+	}
+
 	grate_program_link(cube_program);
 
 	grate_program = grate_program_new(grate, cube_vs, grate_fs, cube_linker);
+	if (!grate_program) {
+		fprintf(stderr, "grate_program_new() failed\n");
+		return 1;
+	}
+
 	grate_program_link(grate_program);
 
 	cube_mvp_loc = grate_get_vertex_uniform_location(cube_program, "mvp");

--- a/tests/grate/cube.c
+++ b/tests/grate/cube.c
@@ -191,6 +191,11 @@ int main(int argc, char *argv[])
 	linker = grate_shader_parse_linker_asm(shader_linker);
 
 	program = grate_program_new(grate, vs, fs, linker);
+	if (!program) {
+		fprintf(stderr, "grate_program_new() failed\n");
+		return 1;
+	}
+
 	grate_program_link(program);
 
 	mvp_loc = grate_get_vertex_uniform_location(program, "mvp");

--- a/tests/grate/interactive.c
+++ b/tests/grate/interactive.c
@@ -205,6 +205,11 @@ int main(int argc, char *argv[])
 	}
 
 	cube_program = grate_program_new(grate, cube_vs, cube_fs, cube_linker);
+	if (!cube_program) {
+		fprintf(stderr, "grate_program_new() failed\n");
+		return 1;
+	}
+
 	grate_program_link(cube_program);
 
 	cube_mvp_loc = grate_get_vertex_uniform_location(cube_program, "mvp");

--- a/tests/grate/quad.c
+++ b/tests/grate/quad.c
@@ -111,6 +111,11 @@ int main(int argc, char *argv[])
 	linker = grate_shader_parse_linker_asm(shader_linker);
 
 	program = grate_program_new(grate, vs, fs, linker);
+	if (!program) {
+		fprintf(stderr, "grate_program_new() failed\n");
+		return 1;
+	}
+
 	grate_program_link(program);
 
 	/* Setup context */

--- a/tests/grate/triangle-rotate.c
+++ b/tests/grate/triangle-rotate.c
@@ -117,6 +117,11 @@ int main(int argc, char *argv[])
 	linker = grate_shader_parse_linker_asm(shader_linker);
 
 	program = grate_program_new(grate, vs, fs, linker);
+	if (!program) {
+		fprintf(stderr, "grate_program_new() failed\n");
+		return 1;
+	}
+
 	grate_program_link(program);
 
 	modelview_loc = grate_get_vertex_uniform_location(program, "modelview");

--- a/tests/grate/triangle.c
+++ b/tests/grate/triangle.c
@@ -108,6 +108,11 @@ int main(int argc, char *argv[])
 	linker = grate_shader_parse_linker_asm(shader_linker);
 
 	program = grate_program_new(grate, vs, fs, linker);
+	if (!program) {
+		fprintf(stderr, "grate_program_new() failed\n");
+		return 1;
+	}
+
 	grate_program_link(program);
 
 	/* Setup context */


### PR DESCRIPTION
When running on my upstream-system, I hadn't set up CgDrv yet, so I ended up running the dummy implementation. However, we end up crashing pretty quickly with that one, because of a NULL-pointer being returned.