### PR TITLE
libwrap: do not move memory

### DIFF
--- a/src/libwrap/nvhost.c
+++ b/src/libwrap/nvhost.c
@@ -151,7 +151,7 @@ static void nvmap_file_enter_ioctl_write(struct nvmap_file *nvmap,
 					 struct nvmap_rw_handle *op)
 {
 	struct nvmap_handle *handle;
-	void *src, *dest;
+	void *src;
 	unsigned int i;
 
 	printf("  Write operation:\n");
@@ -169,16 +169,11 @@ static void nvmap_file_enter_ioctl_write(struct nvmap_file *nvmap,
 		return;
 	}
 
-	dest = handle->buffer + op->offset;
 	src = (void *)(uintptr_t)op->addr;
 
 	for (i = 0; i < op->count; i++) {
 		print_hexdump(stdout, DUMP_PREFIX_NONE, "  ", src,
 			      op->elem_size, 16, true);
-
-		memcpy(dest, src, op->elem_size);
-
-		dest += op->hmem_stride;
 		src += op->user_stride;
 	}
 }


### PR DESCRIPTION
We're peeking into what the blob asks the kernel to do, not trying
to take over the job. In this case, we're probably not equipped to
do it either, as this is probably intended to be done on physical
addresses, not virtual ones.