### PR TITLE
Make libgrate usable externally and some fixes along with it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.la
 *.lo
 *.o
+*.pc
 .deps
 .libs
 aclocal.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,14 @@
 ACLOCAL_AMFLAGS = -I m4
 
+grateincludedir = $(includedir)/libgrate
+
+grateinclude_HEADERS = \
+	include/host1x.h \
+	include/tgr_3d.xml.h \
+	src/libgrate/grate.h \
+	src/libgrate/grate-3d-ctx.h \
+	src/libgrate/matrix.h
+
 SUBDIRS = \
 	include \
 	src \

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AM_PROG_CC_C_O
 AC_PROG_INSTALL
 AM_PROG_LEX
 AC_PROG_YACC
+PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES(DevIL, ILU)
 PKG_CHECK_MODULES(PNG, libpng)
@@ -57,6 +58,10 @@ AM_CONDITIONAL([ENABLE_CGC], [test "x$enable_cgc" = "xyes"])
 AC_CHECK_HEADER([envytools/rnn.h],
 	[AC_CHECK_LIB([rnn], [rnn_init], [enable_rnn=yes], [enable_rnn=no], [-lenvyutil -lxml2])])
 AM_CONDITIONAL([ENABLE_RNN], [test "x$enable_rnn" = "xyes"])
+
+AC_CONFIG_FILES([
+	src/libgrate/libgrate.pc
+])
 
 AC_OUTPUT([
 	Makefile

--- a/include/host1x.h
+++ b/include/host1x.h
@@ -161,12 +161,12 @@ int host1x_overlay_set(struct host1x_overlay *overlay,
 
 #define HOST1X_BO_CREATE(host1x, size, flags)				\
 ({									\
-	struct host1x_bo *bo = host1x_bo_create(host1x, size, flags);	\
-	if (!bo)							\
+	struct host1x_bo *_bo_ = host1x_bo_create(host1x, size, flags);	\
+	if (!_bo_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_bo_create() failed\n",	\
 			__FILE__, __LINE__);				\
-	bo;								\
+	_bo_;								\
 })
 
 struct host1x_bo *host1x_bo_create(struct host1x *host1x, size_t size,
@@ -175,12 +175,12 @@ void host1x_bo_free(struct host1x_bo *bo);
 
 #define HOST1X_BO_INVALIDATE(bo, offset, length)			\
 ({									\
-	int err = host1x_bo_invalidate(bo, offset, length);		\
-	if (err)							\
+	int _err_ = host1x_bo_invalidate(bo, offset, length);		\
+	if (_err_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_bo_invalidate() failed %d\n",\
-			__FILE__, __LINE__, err);			\
-	err;								\
+			__FILE__, __LINE__, _err_);			\
+	_err_;								\
 })
 
 int host1x_bo_invalidate(struct host1x_bo *bo, unsigned long offset,
@@ -188,12 +188,12 @@ int host1x_bo_invalidate(struct host1x_bo *bo, unsigned long offset,
 
 #define HOST1X_BO_FLUSH(bo, offset, length)				\
 ({									\
-	int err = host1x_bo_flush(bo, offset, length);			\
-	if (err)							\
+	int _err_ = host1x_bo_flush(bo, offset, length);		\
+	if (_err_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_bo_flush() failed %d\n",	\
-			__FILE__, __LINE__, err);			\
-	err;								\
+			__FILE__, __LINE__, _err_);			\
+	_err_;								\
 })
 
 int host1x_bo_flush(struct host1x_bo *bo, unsigned long offset,
@@ -201,24 +201,24 @@ int host1x_bo_flush(struct host1x_bo *bo, unsigned long offset,
 
 #define HOST1X_BO_MMAP(bo, ptr)						\
 ({									\
-	int err = host1x_bo_mmap(bo, ptr);				\
-	if (err)							\
+	int _err_ = host1x_bo_mmap(bo, ptr);				\
+	if (_err_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_bo_mmap() failed %d\n",	\
-			__FILE__, __LINE__, err);			\
-	err;								\
+			__FILE__, __LINE__, _err_);			\
+	_err_;								\
 })
 
 int host1x_bo_mmap(struct host1x_bo *bo, void **ptr);
 
 #define HOST1X_BO_WRAP(bo, offset, size)				\
 ({									\
-	struct host1x_bo *wrap = host1x_bo_wrap(bo, offset, size);	\
-	if (!wrap)							\
+	struct host1x_bo *_wrap_ = host1x_bo_wrap(bo, offset, size);	\
+	if (!_wrap_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_bo_wrap() failed\n",	\
 			__FILE__, __LINE__);				\
-	wrap;								\
+	_wrap_;								\
 })
 
 struct host1x_bo *host1x_bo_wrap(struct host1x_bo *bo,
@@ -268,12 +268,12 @@ struct host1x_job {
 
 #define HOST1X_JOB_CREATE(syncpt, increments)				\
 ({									\
-	struct host1x_job *job = host1x_job_create(syncpt, increments);	\
-	if (!job)							\
+	struct host1x_job *_job_ = host1x_job_create(syncpt, increments);\
+	if (!_job_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_job_create() failed\n",	\
 			__FILE__, __LINE__);				\
-	job;								\
+	_job_;								\
 })
 
 struct host1x_job *host1x_job_create(uint32_t syncpt, uint32_t increments);
@@ -281,12 +281,12 @@ void host1x_job_free(struct host1x_job *job);
 
 #define HOST1X_JOB_APPEND(job, bo, offset)				\
 ({									\
-	struct host1x_pushbuf *pb = host1x_job_append(job, bo, offset);	\
-	if (!pb)							\
+	struct host1x_pushbuf *_pb_ = host1x_job_append(job, bo, offset);\
+	if (!_pb_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_job_append() failed\n",	\
 			__FILE__, __LINE__);				\
-	pb;								\
+	_pb_;								\
 })
 
 struct host1x_pushbuf *host1x_job_append(struct host1x_job *job,
@@ -305,12 +305,12 @@ static inline int host1x_pushbuf_push_float(struct host1x_pushbuf *pb, float f)
 
 #define HOST1X_PUSHBUF_RELOCATE(pb, target, offset, shift)		\
 ({									\
-	int err = host1x_pushbuf_relocate(pb, target, offset, shift);	\
-	if (err)							\
+	int _err_ = host1x_pushbuf_relocate(pb, target, offset, shift);	\
+	if (_err_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_pushbuf_relocate() failed %d\n",\
-			__FILE__, __LINE__, err);			\
-	err;								\
+			__FILE__, __LINE__, _err_);			\
+	_err_;								\
 })
 
 int host1x_pushbuf_relocate(struct host1x_pushbuf *pb, struct host1x_bo *target,
@@ -318,36 +318,36 @@ int host1x_pushbuf_relocate(struct host1x_pushbuf *pb, struct host1x_bo *target,
 
 #define HOST1X_CLIENT_SUBMIT(client, job)				\
 ({									\
-	int err = host1x_client_submit(client, job);			\
-	if (err)							\
+	int _err_ = host1x_client_submit(client, job);			\
+	if (_err_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_client_submit() failed %d\n",\
-			__FILE__, __LINE__, err);			\
-	err;								\
+			__FILE__, __LINE__, _err_);			\
+	_err_;								\
 })
 
 int host1x_client_submit(struct host1x_client *client, struct host1x_job *job);
 
 #define HOST1X_CLIENT_FLUSH(client, fence)				\
 ({									\
-	int err = host1x_client_flush(client, fence);			\
-	if (err)							\
+	int _err_ = host1x_client_flush(client, fence);			\
+	if (_err_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_client_flush() failed %d\n",\
-			__FILE__, __LINE__, err);			\
-	err;								\
+			__FILE__, __LINE__, _err_);			\
+	_err_;								\
 })
 
 int host1x_client_flush(struct host1x_client *client, uint32_t *fence);
 
 #define HOST1X_CLIENT_WAIT(client, fence, timeout)			\
 ({									\
-	int err = host1x_client_wait(client, fence, timeout);		\
-	if (err)							\
+	int _err_ = host1x_client_wait(client, fence, timeout);		\
+	if (_err_)							\
 		fprintf(stderr,						\
 			"ERROR: %s:%d: host1x_client_wait() failed %d\n",\
-			__FILE__, __LINE__, err);			\
-	err;								\
+			__FILE__, __LINE__, _err_);			\
+	_err_;								\
 })
 
 int host1x_client_wait(struct host1x_client *client, uint32_t fence,

--- a/include/host1x.h
+++ b/include/host1x.h
@@ -370,6 +370,11 @@ struct host1x_gr3d;
 int host1x_gr2d_clear(struct host1x_gr2d *gr2d,
 		      struct host1x_pixelbuffer *pixbuf,
 		      uint32_t color);
+int host1x_gr2d_clear2(struct host1x_gr2d *gr2d,
+		       struct host1x_pixelbuffer *pixbuf,
+		       uint32_t color,
+		       unsigned int x, unsigned int y,
+		       unsigned int width, unsigned int height);
 int host1x_gr2d_blit(struct host1x_gr2d *gr2d,
 		     struct host1x_pixelbuffer *src,
 		     struct host1x_pixelbuffer *dst,

--- a/include/host1x.h
+++ b/include/host1x.h
@@ -133,7 +133,7 @@ int host1x_pixelbuffer_load_data(struct host1x *host1x,
 				 enum pixel_format data_format,
 				 enum layout_format data_layout);
 
-struct host1x *host1x_open(bool open_display);
+struct host1x *host1x_open(bool open_display, int fd);
 void host1x_close(struct host1x *host1x);
 
 struct host1x_display *host1x_get_display(struct host1x *host1x);

--- a/include/host1x.h
+++ b/include/host1x.h
@@ -133,7 +133,7 @@ int host1x_pixelbuffer_load_data(struct host1x *host1x,
 				 enum pixel_format data_format,
 				 enum layout_format data_layout);
 
-struct host1x *host1x_open(void);
+struct host1x *host1x_open(bool open_display);
 void host1x_close(struct host1x *host1x);
 
 struct host1x_display *host1x_get_display(struct host1x *host1x);

--- a/src/libgrate/Makefile.am
+++ b/src/libgrate/Makefile.am
@@ -82,3 +82,6 @@ libgrate_la_SOURCES += \
 	linker_disasm.c \
 	vertex_asm.tab.c \
 	vertex_disasm.c
+
+pkgconfigdir = ${libdir}/pkgconfig
+pkgconfig_DATA = libgrate.pc

--- a/src/libgrate/Makefile.am
+++ b/src/libgrate/Makefile.am
@@ -1,4 +1,4 @@
-noinst_LTLIBRARIES = libgrate.la
+lib_LTLIBRARIES = libgrate.la
 
 libgrate_la_CPPFLAGS = \
 	-I$(top_srcdir)/include

--- a/src/libgrate/Makefile.am
+++ b/src/libgrate/Makefile.am
@@ -50,22 +50,22 @@ CLEANFILES = \
 	lex.vertex_asm.c
 
 lex.vertex_asm.c: vertex_asm_lexer.l vertex_asm.tab.c
-	$(LEX) -P vertex_asm --nounput vertex_asm_lexer.l
+	$(LEX) -P vertex_asm --nounput $(srcdir)/vertex_asm_lexer.l
 
 vertex_asm.tab.c: vertex_asm_parser.y
-	$(YACC) -p vertex_asm -b vertex_asm -d --debug vertex_asm_parser.y
+	$(YACC) -p vertex_asm -b vertex_asm -d --debug $(srcdir)/vertex_asm_parser.y
 
 lex.fragment_asm.c: fragment_asm_lexer.l fragment_asm.tab.c
-	$(LEX) -P fragment_asm --nounput fragment_asm_lexer.l
+	$(LEX) -P fragment_asm --nounput $(srcdir)/fragment_asm_lexer.l
 
 fragment_asm.tab.c: fragment_asm_parser.y
-	$(YACC) -p fragment_asm -b fragment_asm -d --debug fragment_asm_parser.y
+	$(YACC) -p fragment_asm -b fragment_asm -d --debug $(srcdir)/fragment_asm_parser.y
 
 lex.linker_asm.c: linker_asm_lexer.l linker_asm.tab.c
-	$(LEX) -P linker_asm --nounput linker_asm_lexer.l
+	$(LEX) -P linker_asm --nounput $(srcdir)/linker_asm_lexer.l
 
 linker_asm.tab.c: linker_asm_parser.y
-	$(YACC) -p linker_asm -b linker_asm -d --debug linker_asm_parser.y
+	$(YACC) -p linker_asm -b linker_asm -d --debug $(srcdir)/linker_asm_parser.y
 
 libgrate_la_SOURCES += \
 	fragment_asm.tab.c \

--- a/src/libgrate/Makefile.am
+++ b/src/libgrate/Makefile.am
@@ -8,6 +8,7 @@ libgrate_la_CFLAGS = \
 
 libgrate_la_SOURCES = \
 	display.c \
+	fragment_asm.h \
 	grate.c \
 	grate.h \
 	grate-asm.c \
@@ -15,12 +16,16 @@ libgrate_la_SOURCES = \
 	grate-texture.c \
 	grate-2d.c \
 	grate-3d.c \
+	grate-3d.h \
 	grate-3d-ctx.c \
+	grate-3d-ctx.h \
 	libgrate-private.h \
+	linker_asm.h \
 	matrix.c \
 	matrix.h \
 	profile.c \
-	shader-cgc.c
+	shader-cgc.c \
+	vpe_vliw.h
 
 libgrate_la_LIBADD = \
 	../libcgc/libcgc.la \

--- a/src/libgrate/fragment_disasm.c
+++ b/src/libgrate/fragment_disasm.c
@@ -644,9 +644,9 @@ static const char * disassemble_tex(const tex_instr *tex)
 	char *buf = ret;
 
 	if (tex->enable_bias) {
-		buf += sprintf(buf, "tex ");
-	} else {
 		buf += sprintf(buf, "txb ");
+	} else {
+		buf += sprintf(buf, "tex ");
 	}
 
 	if (tex->sample_dst_regs_select) {

--- a/src/libgrate/grate-texture.c
+++ b/src/libgrate/grate-texture.c
@@ -274,6 +274,18 @@ void grate_texture_clear(struct grate *grate, struct grate_texture *tex,
 		grate_error("host1x_gr2d_clear() failed: %d\n", err);
 }
 
+void grate_texture_clear2(struct grate *grate, struct grate_texture *tex,
+			 uint32_t color, unsigned x, unsigned y,
+			 unsigned width, unsigned height)
+{
+	struct host1x_gr2d *gr2d = host1x_get_gr2d(grate->host1x);
+	int err;
+
+	err = host1x_gr2d_clear2(gr2d, tex->pixbuf, color, x, y, width, height);
+	if (err < 0)
+		grate_error("host1x_gr2d_clear() failed: %d\n", err);
+}
+
 static int alloc_mipmap(struct grate *grate, struct grate_texture *tex)
 {
 	struct host1x_pixelbuffer *pixbuf = tex->pixbuf;

--- a/src/libgrate/grate-texture.c
+++ b/src/libgrate/grate-texture.c
@@ -468,3 +468,24 @@ out:
 
 	return err;
 }
+
+int grate_texture_blit(struct grate *grate,
+		       struct grate_texture *src_tex,
+		       struct grate_texture *dst_tex,
+		       unsigned sx, unsigned sy, unsigned sw, unsigned sh,
+		       unsigned dx, unsigned dy, unsigned dw, unsigned dh)
+{
+	struct host1x_gr2d *gr2d = host1x_get_gr2d(grate->host1x);
+	struct host1x_pixelbuffer *src_pixbuf = src_tex->pixbuf;
+	struct host1x_pixelbuffer *dst_pixbuf = dst_tex->pixbuf;
+	int err;
+
+	if (sw == dw && sh == dh)
+		err = host1x_gr2d_blit(gr2d, src_pixbuf, dst_pixbuf,
+				       sx, sy, dx, dy, dw, dh);
+	else
+		err = host1x_gr2d_surface_blit(gr2d, src_pixbuf, dst_pixbuf,
+					       sx, sy, sw, sh, dx, dy, dw, dh);
+
+	return err;
+}

--- a/src/libgrate/grate.c
+++ b/src/libgrate/grate.c
@@ -43,23 +43,39 @@
 static bool termio_adjusted;
 static tcflag_t saved_c_lflag;
 
-struct host1x_bo *grate_bo_create_from_data(struct grate *grate, size_t size,
-					   unsigned long flags,
-					   const void *data)
+struct host1x_bo *grate_bo_create_and_map(struct grate *grate,
+					  unsigned long flags,
+					  size_t size, void **map)
 {
 	struct host1x_bo *bo;
-	void *map;
 	int err;
 
 	bo = HOST1X_BO_CREATE(grate->host1x, size, flags);
 	if (!bo)
 		return NULL;
 
-	err = HOST1X_BO_MMAP(bo, &map);
+	if (!map)
+		return bo;
+
+	err = HOST1X_BO_MMAP(bo, map);
 	if (err != 0) {
 		host1x_bo_free(bo);
 		return NULL;
 	}
+
+	return bo;
+}
+
+struct host1x_bo *grate_bo_create_from_data(struct grate *grate, size_t size,
+					    unsigned long flags,
+					    const void *data)
+{
+	struct host1x_bo *bo;
+	void *map;
+
+	bo = grate_bo_create_and_map(grate, flags, size, &map);
+	if (!bo)
+		return NULL;
 
 	memcpy(map, data, size);
 

--- a/src/libgrate/grate.c
+++ b/src/libgrate/grate.c
@@ -76,8 +76,9 @@ bool grate_parse_command_line(struct grate_options *options, int argc,
 		{ "width", 1, NULL, 'w' },
 		{ "height", 1, NULL, 'h' },
 		{ "vsync", 0, NULL, 'v' },
+		{ "nodisplay", 0, NULL, 'n' },
 	};
-	static const char opts[] = "fw:h:v";
+	static const char opts[] = "fw:h:vn";
 	int opt;
 
 	options->fullscreen = false;
@@ -105,6 +106,10 @@ bool grate_parse_command_line(struct grate_options *options, int argc,
 			options->vsync = true;
 			break;
 
+		case 'n':
+			options->nodisplay = true;
+			break;
+
 		default:
 			return false;
 		}
@@ -121,13 +126,16 @@ struct grate *grate_init(struct grate_options *options)
 	if (!grate)
 		return NULL;
 
-	grate->host1x = host1x_open();
+	grate->host1x = host1x_open(!options->nodisplay);
 	if (!grate->host1x) {
 		free(grate);
 		return NULL;
 	}
 
 	grate->options = options;
+
+	if (grate->options->nodisplay)
+		return grate;
 
 	grate->display = grate_display_open(grate);
 	if (grate->display) {

--- a/src/libgrate/grate.c
+++ b/src/libgrate/grate.c
@@ -118,7 +118,7 @@ bool grate_parse_command_line(struct grate_options *options, int argc,
 	return true;
 }
 
-struct grate *grate_init(struct grate_options *options)
+struct grate *grate_init2(struct grate_options *options, int fd)
 {
 	struct grate *grate;
 
@@ -126,7 +126,7 @@ struct grate *grate_init(struct grate_options *options)
 	if (!grate)
 		return NULL;
 
-	grate->host1x = host1x_open(!options->nodisplay);
+	grate->host1x = host1x_open(!options->nodisplay, fd);
 	if (!grate->host1x) {
 		free(grate);
 		return NULL;
@@ -149,6 +149,11 @@ struct grate *grate_init(struct grate_options *options)
 	}
 
 	return grate;
+}
+
+struct grate *grate_init(struct grate_options *options)
+{
+	return grate_init2(options, -1);
 }
 
 void grate_exit(struct grate *grate)

--- a/src/libgrate/grate.h
+++ b/src/libgrate/grate.h
@@ -55,6 +55,9 @@ void grate_framebuffer_save(struct grate *grate, struct grate_framebuffer *fb,
 			    const char *path);
 void *grate_framebuffer_data(struct grate_framebuffer *fb, bool front);
 
+struct host1x_bo *grate_bo_create_and_map(struct grate *grate,
+					  unsigned long flags,
+					  size_t size, void **map);
 struct host1x_bo *grate_bo_create_from_data(struct grate *grate, size_t size,
 					    unsigned long flags,
 					    const void *data);

--- a/src/libgrate/grate.h
+++ b/src/libgrate/grate.h
@@ -195,6 +195,11 @@ int grate_texture_generate_mipmap(struct grate *grate,
 int grate_texture_load_miplevel(struct grate *grate,
 				struct grate_texture *tex,
 				unsigned level, const char *path);
+int grate_texture_blit(struct grate *grate,
+		       struct grate_texture *src_tex,
+		       struct grate_texture *dst_tex,
+		       unsigned sx, unsigned sy, unsigned sw, unsigned sh,
+		       unsigned dx, unsigned dy, unsigned dw, unsigned dh);
 
 struct grate_font;
 

--- a/src/libgrate/grate.h
+++ b/src/libgrate/grate.h
@@ -73,6 +73,7 @@ struct grate_options {
 bool grate_parse_command_line(struct grate_options *options, int argc,
 			      char *argv[]);
 struct grate *grate_init(struct grate_options *options);
+struct grate *grate_init2(struct grate_options *options, int fd);
 void grate_exit(struct grate *grate);
 
 void grate_clear_color(struct grate *grate, float red, float green, float blue,

--- a/src/libgrate/grate.h
+++ b/src/libgrate/grate.h
@@ -186,6 +186,9 @@ void grate_texture_set_mag_filter(struct grate_texture *tex,
 				  enum grate_textute_filter filter);
 void grate_texture_clear(struct grate *grate, struct grate_texture *texture,
 			 uint32_t color);
+void grate_texture_clear2(struct grate *grate, struct grate_texture *texture,
+			 uint32_t color, unsigned x, unsigned y,
+			 unsigned width, unsigned height);
 int grate_texture_generate_mipmap(struct grate *grate,
 				  struct grate_texture *tex);
 int grate_texture_load_miplevel(struct grate *grate,

--- a/src/libgrate/grate.h
+++ b/src/libgrate/grate.h
@@ -66,6 +66,7 @@ struct host1x_bo *grate_bo_create_from_data(struct grate *grate, size_t size,
 struct grate_options {
 	unsigned int x, y, width, height;
 	bool fullscreen;
+	bool nodisplay;
 	bool vsync;
 };
 

--- a/src/libgrate/libgrate.pc.in
+++ b/src/libgrate/libgrate.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libgrate
+Description: Open source Tegra 2D/3D user-space
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lgrate
+Cflags: -I${includedir} -I${includedir}/grate

--- a/src/libhost1x/Makefile.am
+++ b/src/libhost1x/Makefile.am
@@ -25,6 +25,9 @@ libhost1x_la_SOURCES = \
 	nvhost.h \
 	nvhost-nvmap.c \
 	nvhost-nvmap.h \
+	nvhost-nvmap.h \
+	tegra_dc_ext.h \
+	tegra_drm.h \
 	x11-display.c \
 	x11-display.h
 

--- a/src/libhost1x/host1x-drm.c
+++ b/src/libhost1x/host1x-drm.c
@@ -846,14 +846,16 @@ static void drm_close(struct host1x *host1x)
 	free(drm);
 }
 
-struct host1x *host1x_drm_open(void)
+struct host1x *host1x_drm_open(int fd)
 {
 	struct drm *drm;
-	int fd, err;
+	int err;
 
-	fd = open("/dev/dri/card0", O_RDWR);
-	if (fd < 0)
-		return NULL;
+	if (fd < 0) {
+		fd = open("/dev/dri/card0", O_RDWR);
+		if (fd < 0)
+			return NULL;
+	}
 
 	drm = calloc(1, sizeof(*drm));
 	if (!drm) {

--- a/src/libhost1x/host1x-drm.c
+++ b/src/libhost1x/host1x-drm.c
@@ -883,15 +883,21 @@ struct host1x *host1x_drm_open(void)
 		return NULL;
 	}
 
+	drm->base.gr2d = &drm->gr2d->base;
+	drm->base.gr3d = &drm->gr3d->base;
+
+	return &drm->base;
+}
+
+void host1x_drm_display_init(struct host1x *host1x)
+{
+	struct drm *drm = to_drm(host1x);
+	int err;
+
 	err = drm_display_create(&drm->display, drm);
 	if (err < 0) {
 		host1x_error("drm_display_create() failed: %d\n", err);
 	} else {
 		drm->base.display = &drm->display->base;
 	}
-
-	drm->base.gr2d = &drm->gr2d->base;
-	drm->base.gr3d = &drm->gr3d->base;
-
-	return &drm->base;
 }

--- a/src/libhost1x/host1x-nvhost.c
+++ b/src/libhost1x/host1x-nvhost.c
@@ -217,16 +217,21 @@ struct host1x *host1x_nvhost_open(void)
 	if (!nvhost->gr3d)
 		return NULL;
 
+	nvhost->base.gr2d = &nvhost->gr2d->base;
+	nvhost->base.gr3d = &nvhost->gr3d->base;
+	nvhost->base.framebuffer_init = nvhost_framebuffer_init;
+
+	return &nvhost->base;
+}
+
+void host1x_nvhost_display_init(struct host1x *host1x)
+{
+	struct nvhost *nvhost = to_nvhost(host1x);
+
 	nvhost->display = nvhost_display_create(nvhost);
 	if (!nvhost->display) {
 		host1x_error("nvhost_display_create() failed\n");
 	} else {
 		nvhost->base.display = &nvhost->display->base;
 	}
-
-	nvhost->base.gr2d = &nvhost->gr2d->base;
-	nvhost->base.gr3d = &nvhost->gr3d->base;
-	nvhost->base.framebuffer_init = nvhost_framebuffer_init;
-
-	return &nvhost->base;
 }

--- a/src/libhost1x/host1x-pixelbuffer.c
+++ b/src/libhost1x/host1x-pixelbuffer.c
@@ -43,10 +43,7 @@ struct host1x_pixelbuffer *host1x_pixelbuffer_create(
 	if (!pixbuf)
 		return NULL;
 
-	if (layout == PIX_BUF_LAYOUT_TILED_16x16)
-		pitch = ALIGN(pitch, 256);
-
-	pixbuf->pitch = pitch;
+	pixbuf->pitch = ALIGN(pitch, 256);
 	pixbuf->width = width;
 	pixbuf->height = height;
 	pixbuf->format = format;

--- a/src/libhost1x/host1x-private.h
+++ b/src/libhost1x/host1x-private.h
@@ -121,7 +121,7 @@ struct host1x {
 struct host1x *host1x_nvhost_open(void);
 void host1x_nvhost_display_init(struct host1x *host1x);
 
-struct host1x *host1x_drm_open(void);
+struct host1x *host1x_drm_open(int fd);
 void host1x_drm_display_init(struct host1x *host1x);
 
 #define host1x_error(fmt, args...) \

--- a/src/libhost1x/host1x-private.h
+++ b/src/libhost1x/host1x-private.h
@@ -119,7 +119,10 @@ struct host1x {
 };
 
 struct host1x *host1x_nvhost_open(void);
+void host1x_nvhost_display_init(struct host1x *host1x);
+
 struct host1x *host1x_drm_open(void);
+void host1x_drm_display_init(struct host1x *host1x);
 
 #define host1x_error(fmt, args...) \
 	fprintf(stderr, "ERROR: %s: %d: " fmt, __func__, __LINE__, ##args)

--- a/src/libhost1x/host1x.c
+++ b/src/libhost1x/host1x.c
@@ -29,7 +29,7 @@
 #include "host1x.h"
 #include "host1x-private.h"
 
-struct host1x *host1x_open(void)
+struct host1x *host1x_open(bool open_display)
 {
 	struct host1x *host1x;
 
@@ -39,6 +39,8 @@ struct host1x *host1x_open(void)
 	host1x = host1x_drm_open();
 	if (host1x) {
 		printf("found\n");
+		if (open_display)
+			host1x_drm_display_init(host1x);
 		return host1x;
 	}
 
@@ -49,6 +51,8 @@ struct host1x *host1x_open(void)
 	host1x = host1x_nvhost_open();
 	if (host1x) {
 		printf("found\n");
+		if (open_display)
+			host1x_nvhost_display_init(host1x);
 		return host1x;
 	}
 

--- a/src/libhost1x/host1x.c
+++ b/src/libhost1x/host1x.c
@@ -29,14 +29,14 @@
 #include "host1x.h"
 #include "host1x-private.h"
 
-struct host1x *host1x_open(bool open_display)
+struct host1x *host1x_open(bool open_display, int fd)
 {
 	struct host1x *host1x;
 
 	printf("Looking for Tegra DRM interface...");
 	fflush(stdout);
 
-	host1x = host1x_drm_open();
+	host1x = host1x_drm_open(fd);
 	if (host1x) {
 		printf("found\n");
 		if (open_display)

--- a/tests/grate/Makefile.am
+++ b/tests/grate/Makefile.am
@@ -14,5 +14,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/src/libgrate
 
+AM_LDFLAGS = -static
+
 LDADD = \
 	$(top_builddir)/src/libgrate/libgrate.la

--- a/tests/host1x/Makefile.am
+++ b/tests/host1x/Makefile.am
@@ -1,6 +1,8 @@
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/include
 
+AM_LDFLAGS = -static
+
 noinst_PROGRAMS = \
 	gr2d-clear \
 	gr3d-triangle

--- a/tests/host1x/gr2d-clear.c
+++ b/tests/host1x/gr2d-clear.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 	struct host1x *host1x;
 	int err;
 
-	host1x = host1x_open(true);
+	host1x = host1x_open(true, -1);
 	if (!host1x) {
 		fprintf(stderr, "host1x_open() failed\n");
 		return 1;

--- a/tests/host1x/gr2d-clear.c
+++ b/tests/host1x/gr2d-clear.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 	struct host1x *host1x;
 	int err;
 
-	host1x = host1x_open();
+	host1x = host1x_open(true);
 	if (!host1x) {
 		fprintf(stderr, "host1x_open() failed\n");
 		return 1;

--- a/tests/host1x/gr3d-triangle.c
+++ b/tests/host1x/gr3d-triangle.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 	struct host1x *host1x;
 	int err;
 
-	host1x = host1x_open(true);
+	host1x = host1x_open(true, -1);
 	if (!host1x) {
 		fprintf(stderr, "host1x_open() failed\n");
 		return 1;

--- a/tests/host1x/gr3d-triangle.c
+++ b/tests/host1x/gr3d-triangle.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 	struct host1x *host1x;
 	int err;
 
-	host1x = host1x_open();
+	host1x = host1x_open(true);
 	if (!host1x) {
 		fprintf(stderr, "host1x_open() failed\n");
 		return 1;

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -5,6 +5,8 @@ noinst_PROGRAMS = \
 	fp20 \
 	fx10
 
+AM_LDFLAGS = -static
+
 assembler_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/src/libgrate


### PR DESCRIPTION
Now libgrate.so and related headers will be installed by "make install". I'm using it for experimental opentegra EXA accel, works good so far. So I added some functionality required for EXA (like texture blit) that is not used by grate itself, maybe it will be useful later.