### PR TITLE
STORE opcode and fancier egl-x11-clear

### DIFF
--- a/src/libgrate/fragment_asm.h
+++ b/src/libgrate/fragment_asm.h
@@ -278,6 +278,17 @@ typedef union fragment_tex_instruction {
 } tex_instr;
 
 typedef union fragment_dw_instruction {
+	struct __attribute__((packed)) {
+		unsigned enable:1;
+		unsigned unk_1:1;
+		unsigned render_target_index:4;
+		unsigned unk_6_9:4;
+		unsigned stencil_write:1;
+		unsigned unk_11_14:4;
+		unsigned src_regs_select:1;
+		unsigned unk_16_31:16;
+	};
+
 	uint32_t data;
 } dw_instr;
 

--- a/src/libgrate/fragment_asm_lexer.l
+++ b/src/libgrate/fragment_asm_lexer.l
@@ -205,5 +205,14 @@ tex[0-9]{1,2}		{
 TEX			return T_TEX_OPCODE;
 TXB			return T_TXB_OPCODE;
 
+"store"			return T_DW_STORE;
+
+rt[0-9]{1,2}		{
+				fragment_asmlval.u = atoi(yytext + 2);
+				return T_DW_RENDER_TARGET;
+			}
+
+"stencil"		return T_DW_STENCIL;
+
 .			return T_SYNTAX_ERROR;
 %%

--- a/src/libgrate/fragment_asm_parser.y
+++ b/src/libgrate/fragment_asm_parser.y
@@ -226,6 +226,10 @@ static uint32_t float_to_fx10(float f)
 %token T_ALU_X4
 %token T_ALU_DIV2
 
+%token T_DW_STORE
+%token T_DW_STENCIL
+%token <u> T_DW_RENDER_TARGET
+
 %token <u> T_HEX
 %token <f> T_FLOAT
 
@@ -1482,6 +1486,36 @@ DW_INSTRUCTION:
 	T_DW T_HEX
 	{
 		asm_dw_instructions[asm_fs_instructions_nb].data = $2;
+	}
+	|
+	T_DW T_DW_STORE T_DW_RENDER_TARGET ',' T_ROW_REGISTER ',' T_ROW_REGISTER
+	{
+		asm_dw_instructions[asm_fs_instructions_nb].enable = 1;
+
+		if ($5 == 0 && $7 == 1) {
+			asm_dw_instructions[asm_fs_instructions_nb].src_regs_select = 0;
+		}
+		else if ($5 == 2 && $7 == 3) {
+			asm_dw_instructions[asm_fs_instructions_nb].src_regs_select = 1;
+		}
+		else {
+			PARSE_ERROR("DW source registers should be either \"r0,r1\" or \"r2,r3\"");
+		}
+
+		if ($3 > 15) {
+			PARSE_ERROR("Invalid DW render target, 15 is maximum");
+		}
+
+		asm_dw_instructions[asm_fs_instructions_nb].render_target_index = $3;
+		asm_dw_instructions[asm_fs_instructions_nb].unk_16_31 = 2;
+	}
+	|
+	T_DW T_DW_STORE T_DW_STENCIL
+	{
+		asm_dw_instructions[asm_fs_instructions_nb].enable = 1;
+		asm_dw_instructions[asm_fs_instructions_nb].stencil_write = 1;
+		asm_dw_instructions[asm_fs_instructions_nb].render_target_index = 2;
+		asm_dw_instructions[asm_fs_instructions_nb].unk_16_31 = 2;
 	}
 	|
 	T_DW T_OPCODE_NOP

--- a/src/libgrate/fragment_disasm.c
+++ b/src/libgrate/fragment_disasm.c
@@ -674,6 +674,36 @@ static const char * disassemble_tex(const tex_instr *tex)
 	return ret;
 }
 
+static const char * disassemble_dw(const dw_instr *dw)
+{
+	static char ret[64];
+	char *buf = ret;
+
+	if (dw->enable) {
+		buf += sprintf(buf, "store ");
+
+		if (dw->stencil_write && dw->render_target_index == 2) {
+			buf += sprintf(buf, "stencil");
+		} else {
+			buf += sprintf(buf, "rt%d, ", dw->render_target_index);
+
+			if (dw->src_regs_select) {
+				buf += sprintf(buf, "r2, r3");
+			} else {
+				buf += sprintf(buf, "r0, r1");
+			}
+		}
+	} else {
+		buf += sprintf(buf, "NOP");
+	}
+
+	if (dw->unk_1 || dw->unk_6_9 || dw->unk_11_14 || dw->unk_16_31 != 2) {
+		sprintf(buf, " // 0x%08X", dw->data);
+	}
+
+	return ret;
+}
+
 const char * fragment_pipeline_disassemble(
 	const pseq_instr *pseq,
 	const mfu_instr *mfu, unsigned mfu_nb,
@@ -712,7 +742,7 @@ const char * fragment_pipeline_disassemble(
 	}
 
 	if (dw->data != 0x00000000) {
-		buf += sprintf(buf, "\tDW:\t0x%08X\n", dw->data);
+		buf += sprintf(buf, "\tDW:\t%s\n", disassemble_dw(dw));
 	}
 
 	sprintf(buf, ";");

--- a/src/libgrate/grate-font.c
+++ b/src/libgrate/grate-font.c
@@ -81,11 +81,11 @@ EXEC								\n\
 		mul1: bar, sfu, bar1				\n\
 		ipl: t0.fp20, t0.fp20, NOP, NOP			\n\
 								\n\
-	TEX:	tex r2, r3, tex0, r0, r1, r2			\n\
+	TEX:	tex r0, r1, tex0, r0, r1, r2			\n\
 								\n\
-	ALU:	ALU0:	MAD kill, r3.h, #1, #0 (eq)		\n\
+	ALU:	ALU0:	MAD kill, r1.h, #1, #0 (eq)		\n\
 								\n\
-	DW:	0x00028005					\n\
+	DW:	store rt1, r0, r1				\n\
 ;								\n\
 ";
 

--- a/tests/gles2/Makefile.am
+++ b/tests/gles2/Makefile.am
@@ -4,7 +4,7 @@ libcommon_la_SOURCES = \
 	common.c \
 	common.h
 
-libcommon_la_LIBADD = $(X11_LIBS) $(GLES2_LIBS) $(PNG_LIBS) $(DevIL_LIBS)
+libcommon_la_LIBADD = $(X11_LIBS) $(GLES2_LIBS) $(PNG_LIBS) $(DevIL_LIBS) -lm
 
 AM_CFLAGS = -I$(top_srcdir)/src/libgrate $(GLES2_CFLAGS) $(PNG_CFLAGS)
 AM_LDFLAGS = -static

--- a/tests/gles2/egl-x11-clear.c
+++ b/tests/gles2/egl-x11-clear.c
@@ -22,6 +22,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -223,11 +224,15 @@ static void window_show(struct window *window)
 
 static void draw(struct window *window)
 {
+	static float incr = 0.0f, incg = 0.0f, incb = 0.0f;
+	float r = sinf(incr), g = sinf(incg), b = sinf(incb);
+	incr += 0.010f; incg += 0.011f; incb += 0.012f;
+
 	printf("=== calling glViewport()\n");
 	glViewport(0, 0, window->width, window->height);
 	glFlush();
 	printf("=== calling glClearColor()\n");
-	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+	glClearColor(fabs(r), fabs(g), fabs(b), 1.0f);
 	glFlush();
 	printf("=== calling glClear()\n");
 	glClear(GL_COLOR_BUFFER_BIT);
@@ -245,7 +250,8 @@ static void event_loop(struct window *window)
 		char buffer[16];
 		XEvent event;
 
-		XNextEvent(window->display->x11, &event);
+		if (!XCheckWindowEvent(window->display->x11, window->x11, ~0l, &event))
+			redraw = true;
 
 		switch (event.type) {
 		case Expose:

--- a/tests/grate/asm/cube2_fs.txt
+++ b/tests/grate/asm/cube2_fs.txt
@@ -14,5 +14,5 @@ EXEC
 
 	TEX:	tex r2, r3, tex0, r0, r1, r2
 
-	DW:	0x00028005
+	DW:	store rt1, r2, r3
 ;

--- a/tests/grate/asm/cube2_grate_fs.txt
+++ b/tests/grate/asm/cube2_grate_fs.txt
@@ -37,5 +37,5 @@ EXEC
 	ALU:
 		ALU0:	MAD kill, cr0, cr2, #0
 
-	DW:	0x00028005
+	DW:	store rt1, r2, r3
 ;

--- a/tests/grate/asm/filter_quad_fs.txt
+++ b/tests/grate/asm/filter_quad_fs.txt
@@ -22,5 +22,5 @@ EXEC
 EXEC
 	TEX:	txb r2, r3, tex0, r0, r1, r2, r3
 
-	DW:	0x00028005
+	DW:	store rt1, r2, r3
 ;

--- a/tests/grate/asm/fs_uniform.txt
+++ b/tests/grate/asm/fs_uniform.txt
@@ -14,5 +14,5 @@ EXEC
 		ALU1:	MAD  r3.l*,  u2,            #1,         #0,         #1
 		ALU2:	MAD  r2.*h,  u31.l,         #1,         #0,         #1
 		ALU3:	MAD  r2.l*,  u31.h,         #1,         #0,         #1
-	DW:	0x00028005
+	DW:	store rt1, r2, r3
 ;

--- a/tests/grate/asm/fs_vs_tests.txt
+++ b/tests/grate/asm/fs_vs_tests.txt
@@ -13,5 +13,5 @@ EXEC
 		ALU1:	MAD  r3.l*,  r2,         #1,         #0,         #1
 		ALU2:	MAD  r2.*h,  r0,         #1,         #0,         #1
 		ALU3:	MAD  r2.l*,  r1,         #1,         #0,         #1
-	DW:	0x00028005
+	DW:	store rt1, r2, r3
 ;

--- a/tests/grate/asm/stencil_test_fs.txt
+++ b/tests/grate/asm/stencil_test_fs.txt
@@ -13,5 +13,5 @@ EXEC
 		ALU2:	MAD  r2.*h,  #1, #0, #0 // Green
 		ALU3:	MAD  r2.l*,  #1, #0, #0 // Red
 
-	DW:	0x00028005
+	DW:	store rt1, r2, r3
 ;

--- a/tests/grate/asm/stencil_test_fs2.txt
+++ b/tests/grate/asm/stencil_test_fs2.txt
@@ -35,5 +35,5 @@ EXEC
 
 EXEC
 	ALU:	ALU0:	MAD kill, cr0, cr2, #0
-	DW:	0x00028409
+	DW:	store stencil
 ;

--- a/tests/grate/asm/texture_wrap_fs.txt
+++ b/tests/grate/asm/texture_wrap_fs.txt
@@ -24,5 +24,5 @@ EXEC
 EXEC
 	TEX:	tex r2, r3, tex0, r0, r1, r2
 
-	DW:	0x00028005
+	DW:	store rt1, r2, r3
 ;


### PR DESCRIPTION
Replace DW hex with a proper asm instruction and make egl-x11-clear (which is I use as a trivial glClear() mesa test) display something other than black.