### PR TITLE
libhost1x: setup display framebuffer offset

### DIFF
--- a/src/libhost1x/host1x-drm.c
+++ b/src/libhost1x/host1x-drm.c
@@ -552,7 +552,7 @@ static int drm_framebuffer_init(struct host1x *host1x,
 
 	handles[0] = pixbuf->bo->handle;
 	pitches[0] = pixbuf->pitch;
-	offsets[0] = 0;
+	offsets[0] = pixbuf->bo->offset;
 
 	err = drmModeAddFB2(drm->fd, pixbuf->width, pixbuf->height, format,
 			    handles, pitches, offsets, &fb->handle, 0);

--- a/src/libhost1x/nvhost-display.c
+++ b/src/libhost1x/nvhost-display.c
@@ -73,6 +73,7 @@ static int overlay_set(struct host1x_overlay *overlayp,
 	flip.win[1].index = -1;
 	flip.win[2].index = display->plane;
 	flip.win[2].stride = fb->pixbuf->pitch;
+	flip.win[2].offset = fb->pixbuf->bo->offset;
 	flip.win[2].buff_id = fb->pixbuf->bo->handle;
 	flip.win[2].pixformat = pixformat;
 	flip.win[2].w = fb->pixbuf->width << 12;


### PR DESCRIPTION
This fixes tests/host1x displaying garbage at the bottom, it caused by commit
4b0ef36 (setup BO guard on both sides) that prepends BO with a guard, guard
is enabled by default globally, but disabled for grate tests by default, so
the garbage is also displayed by grate tests if guard is enabled (-g option).