### PR TITLE
libgrate: printf long long to avoid warning

### DIFF
--- a/src/libgrate/grate-asm.c
+++ b/src/libgrate/grate-asm.c
@@ -56,8 +56,8 @@ static char *read_file(const char *path)
 
 	data = calloc(1, sb.st_size + 1);
 	if (!data) {
-		grate_error("Failed to get allocate %lu: %s\n",
-			    sb.st_size, path);
+		grate_error("Failed to get allocate %ju: %s\n",
+			    (uintmax_t)sb.st_size, path);
 		goto cleanup;
 	}
 

--- a/src/libgrate/grate-asm.c
+++ b/src/libgrate/grate-asm.c
@@ -56,7 +56,7 @@ static char *read_file(const char *path)
 
 	data = calloc(1, sb.st_size + 1);
 	if (!data) {
-		grate_error("Failed to get allocate %ju: %s\n",
+		grate_error("Failed to allocate %ju: %s\n",
 			    (uintmax_t)sb.st_size, path);
 		goto cleanup;
 	}


### PR DESCRIPTION
off_t doesn't have a designated format, so let's use uintmax_t
instead to prevent a warning.