### PR TITLE
Fixup meson + libwrap

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,14 +16,6 @@ if egl.found() and x11.found()
 	gles2 = dependency('glesv2', required : false)
 endif
 
-rnn_enable = ''
-librnn = cc.find_library('rnn', required : false)
-if librnn.found()
-	if cc.has_header('envytools/rnn.h')
-		rnn_enable = '-DENABLE_RNN'
-	endif
-endif
-
 subdir('src')
 subdir('tools')
 subdir('tests')

--- a/src/libwrap/meson.build
+++ b/src/libwrap/meson.build
@@ -8,10 +8,20 @@ libwrap_sources =  files(
 	'utils.h'
 )
 
+libwrap_deps = [libdl]
+libwrap_c_args = ['-U_FILE_OFFSET_BITS']
+
+librnn = cc.find_library('rnn', required : false)
+if librnn.found() and cc.has_header('envytools/rnn.h')
+	libenvyutil = cc.find_library('envyutil')
+	libxml2 = cc.find_library('xml2')
+	libwrap_deps += [librnn, libenvyutil, libxml2]
+	libwrap_c_args += ['-DENABLE_RNN']
+endif
+
 libwrap = shared_library(
 	'wrap',
 	libwrap_sources,
-	dependencies: [libdl, librnn],
-	cpp_args: rnn_enable,
-	c_args: '-U_FILE_OFFSET_BITS'
+	dependencies: libwrap_deps,
+	c_args: libwrap_c_args
 )

--- a/src/libwrap/meson.build
+++ b/src/libwrap/meson.build
@@ -12,5 +12,6 @@ libwrap = shared_library(
 	'wrap',
 	libwrap_sources,
 	dependencies: [libdl, librnn],
-	cpp_args : rnn_enable
+	cpp_args: rnn_enable,
+	c_args: '-U_FILE_OFFSET_BITS'
 )


### PR DESCRIPTION
The meson support for libwrap was broken for two reasons:
- the librnn-integration just plain didn't work
- `-D_FILE_OFFSET_BITS="64"` renamed our `open`-symbol to `open64`, breaking ioctl hooking. 