### PR TITLE
meson: ensure input is at the end

### DIFF
--- a/src/libgrate/meson.build
+++ b/src/libgrate/meson.build
@@ -26,7 +26,7 @@ libgrate_sources = files(
 parser_gen = generator(
 	yacc,
 	output : ['@BASENAME@.tab.c', '@BASENAME@.tab.h'],
-	arguments : ['-d', '-o', '@OUTPUT0@', '@INPUT@', '@EXTRA_ARGS@']
+	arguments : ['-d', '-o', '@OUTPUT0@', '@EXTRA_ARGS@', '@INPUT@']
 )
 
 lex_gen = generator(


### PR DESCRIPTION
Seems some versions of yacc requires this.