### PR TITLE
tests/gles1: fix compilation with newer mesa

### DIFF
--- a/tests/gles1/common.h
+++ b/tests/gles1/common.h
@@ -75,31 +75,11 @@ struct pbuffer *pbuffer_create(unsigned int width, unsigned int height);
 void pbuffer_free(struct pbuffer *pbuffer);
 bool pbuffer_save(struct pbuffer *pbuffer, const char *filename);
 
-GLuint glsl_shader_load(GLenum type, const GLchar *lines[], size_t count);
-GLuint glsl_program_create(GLuint vertex, GLuint fragment);
-void glsl_program_link(GLuint program);
-
-struct framebuffer {
-	unsigned int width;
-	unsigned int height;
-	GLuint texture;
-	GLenum format;
-	GLuint id;
-};
-
-struct framebuffer *framebuffer_create(unsigned int width, unsigned int height,
-				       GLenum format);
-struct framebuffer *display_create(unsigned int width, unsigned int height);
-void framebuffer_free(struct framebuffer *framebuffer);
-void framebuffer_bind(struct framebuffer *framebuffer);
-bool framebuffer_save(struct framebuffer *framebuffer, const char *filename);
-
 struct gles_texture {
 	GLenum format;
 	GLuint id;
 };
 
 struct gles_texture *gles_texture_load(const char *filename);
-void gles_texture_free(struct gles_texture *texture);
 
 #endif


### PR DESCRIPTION
Recent mesa update broke GLES1 tests compilation, seems mesa's GLES includes
got some cleanup and 'GLchar' isn't provided by default anymore, glext.h
should be included explicitly. The offending type is defined in unused
function prototype, let's remove it to fix the issue and some others for
cleanup.

../tests/gles1/common.h:78:44: error: unknown type name 'GLchar'
 GLuint glsl_shader_load(GLenum type, const GLchar *lines[], size_t count);