### PR TITLE
grate: fragment disasm: Correct ALU's disasm formatting

### DIFF
--- a/src/libgrate/fragment_disasm.c
+++ b/src/libgrate/fragment_disasm.c
@@ -738,7 +738,7 @@ const char * fragment_pipeline_disassemble(
 	}
 
 	for (i = 0; i < alu_nb; i++) {
-		buf += sprintf(buf, "\tALU:\n\%s", disassemble_alus(alu + i));
+		buf += sprintf(buf, "\tALU:\n%s", disassemble_alus(alu + i));
 	}
 
 	if (dw->data != 0x00000000) {


### PR DESCRIPTION
This minor typo seems harmless, nevertheless let's correct it.