### PR TITLE
libgrate: linker asm: correct number of used TRAM rows

### DIFF
--- a/src/libgrate/linker_asm.y
+++ b/src/libgrate/linker_asm.y
@@ -155,8 +155,8 @@ instruction:
 		yyval.instr.tram_dst_type_w		= $8.type;
 		yyval.instr.tram_dst_swizzle_w		= $15;
 
-		if ($10 > asm_linker_used_tram_rows_nb) {
-			asm_linker_used_tram_rows_nb = $10;
+		if ($10 >= asm_linker_used_tram_rows_nb) {
+			asm_linker_used_tram_rows_nb = $10 + 1;
 		}
 	}
 	;


### PR DESCRIPTION
Shader linking with more than 1 TRAM row being used works correctly now.