### PR TITLE
libwrap: fix segfaulting with disabled record-replay

### DIFF
--- a/src/libwrap/host1x.c
+++ b/src/libwrap/host1x.c
@@ -737,6 +737,9 @@ static void host1x_file_leave_ioctl_rmfb(struct host1x_file *host1x,
 {
 	struct host1x_bo *bo;
 
+	if (!recorder_enabled())
+		return;
+
 	list_for_each_entry(bo, &host1x->bos, list)
 		if (bo->rec_bo->fb_id == fb_id)
 			return record_del_framebuffer(bo->rec_bo);


### PR DESCRIPTION
There is a missing check for record-replay 'enable' status.