### PR TITLE
support DRM framebuffer modifiers

### DIFF
--- a/src/libhost1x/host1x-framebuffer.c
+++ b/src/libhost1x/host1x-framebuffer.c
@@ -102,6 +102,7 @@ struct host1x_framebuffer *host1x_framebuffer_create(struct host1x *host1x,
 	if (host1x->framebuffer_init) {
 		err = host1x->framebuffer_init(host1x, fb);
 		if (err < 0) {
+			host1x_error("framebuffer_init failed: %d\n", err);
 			host1x_framebuffer_free(fb);
 			fb = NULL;
 		}


### PR DESCRIPTION
DRM framebuffer modifiers are a thing since 4.17 kernel, we have to support them in order to be able to display grate tests.