### PR TITLE
libhost1x: restore 3d triangle host1x test

### DIFF
--- a/src/libhost1x/host1x-gr3d.c
+++ b/src/libhost1x/host1x-gr3d.c
@@ -689,13 +689,15 @@ int host1x_gr3d_triangle(struct host1x_gr3d *gr3d,
 	HOST1X_PUSHBUF_RELOCATE(pb, pixbuf->bo, 0, 0);
 	host1x_pushbuf_push(pb, 0xdeadbeef);
 	/* vertex position attribute */
-	host1x_pushbuf_push(pb, HOST1X_OPCODE_INCR(0x100, 0x01));
+	host1x_pushbuf_push(pb, HOST1X_OPCODE_INCR(0x100, 0x02));
 	HOST1X_PUSHBUF_RELOCATE(pb, gr3d->attributes, 0x30, 0);
 	host1x_pushbuf_push(pb, 0xdeadbeef);
+	host1x_pushbuf_push(pb, 0x0000104d);
 	/* vertex color attribute */
-	host1x_pushbuf_push(pb, HOST1X_OPCODE_INCR(0x102, 0x01));
+	host1x_pushbuf_push(pb, HOST1X_OPCODE_INCR(0x102, 0x02));
 	HOST1X_PUSHBUF_RELOCATE(pb, gr3d->attributes, 0, 0);
 	host1x_pushbuf_push(pb, 0xdeadbeef);
+	host1x_pushbuf_push(pb, 0x0000104d);
 	/* primitive indices */
 	host1x_pushbuf_push(pb, HOST1X_OPCODE_INCR(0x121, 0x03));
 	HOST1X_PUSHBUF_RELOCATE(pb, gr3d->attributes, 0x60, 0);


### PR DESCRIPTION
Commit a9ed912b1698 removed vertex attributes descriptor setup, that broke `test/host1x/host1x_gr3d_triangle`

Thanks @thierryreding for reporting the issue.