### PR TITLE
Fix crashes with dummy host1x

### DIFF
--- a/src/libhost1x/host1x.c
+++ b/src/libhost1x/host1x.c
@@ -56,9 +56,9 @@ struct host1x *host1x_open(bool open_display, int fd)
 		return host1x;
 	}
 
-	printf("not found\n");
+	printf("not found\n\n");
 
-	printf("Using dummy interface\n");
+	printf("Kernel driver interface undetected, continuing using a dummy interface!\n\n");
 	return host1x_dummy_open();
 }
 


### PR DESCRIPTION
I've noticed that some of tests are crashing with the dummy host1x interface while was checking something having kernels TERGA_DRM_STAGING disabled, here is a fix for that.