### PR TITLE
fixed test build

### DIFF
--- a/tests/grate/Makefile.am
+++ b/tests/grate/Makefile.am
@@ -16,7 +16,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/src/libgrate
 
-AM_LDFLAGS = -static
+AM_LDFLAGS = -static -lm
 
 LDADD = \
 	$(top_builddir)/src/libgrate/libgrate.la


### PR DESCRIPTION
Hello,
i got an build error while linking the tests.
~~~
undefined reference to symbol 'powf@@GLIBC_2.27'
~~~
It seems to me that libm is missing in LDFLAGS

adding -lm to the LDFLAGS solved the problem.

Greetings
Jochen